### PR TITLE
Fix for non reference of char pointer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,12 @@ AC_SEARCH_LIBS([strlcpy], [bsd])
 AS_IF([test "x$ac_cv_search_strlcpy" = "x-lbsd"], [AC_CHECK_HEADERS([bsd/string.h])])
 AC_CHECK_FUNCS([strlcpy])
 
+# check if bsd/string.h needs to be included
+dnl Check for the bsd/string.h header
+AC_CHECK_HEADER([bsd/string.h],
+  [AC_DEFINE([HAVE_BSD_STRING_H], [1], [Define if you have <bsd/string.h>])]
+)
+
 # Need the math library
 AC_CHECK_LIB([m],[sin])
 

--- a/palIntin.c
+++ b/palIntin.c
@@ -129,7 +129,7 @@ void palIntin( const char * string, int *nstrt,
      string first and look for the negative */
   hasminus = 0;
   ctemp = strstart;
-  while ( ctemp != '\0' ) {
+  while ( *ctemp ) {
     if (isdigit(*ctemp)) break;
     /* Reset so that - 12345 is not a negative number */
     hasminus = 0;


### PR DESCRIPTION
Hi,

after looking at 
palIntin.c: In function 'palIntin':
palIntin.c:132:17: warning: comparison between pointer and zero character constant [-Wpointer-compare]
  132 |   while ( ctemp != '\0' ) {
      |                 ^~
palIntin.c:132:11: note: did you mean to dereference the pointer?
  132 |   while ( ctemp != '\0' ) {
      |           ^

I think this is wrong and should be while (*ctemp) to actually look for the end of the string.